### PR TITLE
Coverage integrations with Codecov

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -27,4 +27,8 @@ jobs:
           go-version-file: go.mod
       - name: Test Go Packages
         run: |
-          go test -v -cover ./...
+          go test -race -covermode=atomic -coverprofile=coverage.out ./...
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024 Fadhli Dzil Ikram.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Eqtest - Equality test assertions with go-cmp
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/adzil/eqtest.svg)](https://pkg.go.dev/github.com/adzil/eqtest)
+[![codecov](https://codecov.io/github/adzil/eqtest/graph/badge.svg?token=O54SMZGI1T)](https://codecov.io/github/adzil/eqtest)
+
 Eqtest provides equality test assertions API using go-cmp. It is not designed to compete or replace existing assertion frameworks such as testify, but rather to complement where it lacks such as proper equality comparison for complex types.
 
 ## Quick Start


### PR DESCRIPTION
This PR also introduces a MIT license to allow documentation scanning by <https://pkg.go.dev>.